### PR TITLE
Add en translation for the event plugin

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -15,3 +15,4 @@ en:
       private_message: '%{username} sent you a private message in "%{topic}" - %{site_title}'
       linked: '%{username} linked to your post from "%{topic}" - %{site_title}'
       chat_message: '%{username}:'
+      event_reminder: 'Event reminder'


### PR DESCRIPTION
Add missing event title translation

![Screenshot_20240910-225302](https://github.com/user-attachments/assets/7c0868d6-7cf4-4c79-a164-365b72aeee35)
